### PR TITLE
Add Permission Requirement for .Spec

### DIFF
--- a/GhostSpectator/Commands/Spec.cs
+++ b/GhostSpectator/Commands/Spec.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using Exiled.API.Features;
+using Exiled.Permissions.Extensions;
 using CommandSystem;
 
 namespace GhostSpectator.Commands
@@ -16,6 +17,11 @@ namespace GhostSpectator.Commands
 
         public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
         {
+            if (!sender.CheckPermission("gs.spectate"))
+            {
+                response = "You don't have permission to use that command.";
+                return false;
+            }
             if (GhostSpectator.Singleton.Config.GhostSpecSwap == false)
             {
                 response = "This command is disabled.";


### PR DESCRIPTION
This allows server owners to restrict ghosting to specific roles. This way, server owners could allow patrons, or moderators only to spectate. If server owners want to allow everyone to use the command, they can give this permission to the default permission group, allowing everyone to use this command. This could also be implemented with a config option boolean that allows everyone to use the command when true, but restricts it to only users with this permission when false, preventing server owners from needing to add this permission at all if it won't be used.