### PR TITLE
Prevent Ghosts from Upgrading

### DIFF
--- a/GhostSpectator/Config.cs
+++ b/GhostSpectator/Config.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 using Exiled.API.Interfaces;
@@ -74,6 +74,7 @@ namespace GhostSpectator
         public bool StopWarhead { get; set; } = false;
         public bool ToggleWarhead { get; set; } = false;
         public bool InteractScp914 { get; set; } = false;
+        public bool UpgradeInventory914 { get; set; } = false;
         public bool InteractIntercom { get; set; } = false;
         public bool InteractWorkstation { get; set; } = false;
         public bool Contain106 { get; set; } = false;

--- a/GhostSpectator/GhostSpectator.cs
+++ b/GhostSpectator/GhostSpectator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Exiled.API.Enums;
@@ -52,6 +52,7 @@ namespace GhostSpectator
             Events.Scp049.FinishingRecall += _handler.OnFinishingRecall;
             // SCP-914
             Events.Scp914.Activating += _handler.OnActivating;
+            Events.Scp914.UpgradingItems += _handler.OnUpgrading;
             Events.Scp914.ChangingKnobSetting += _handler.OnChangingKnobStatus;
             // Workstation
             Events.Player.ActivatingWorkstation += _handler.OnActivatingWorkstation;


### PR DESCRIPTION
Adds a config to allow ghosts to upgrade items in 914. If set to false, ghosts will not be able to upgrade inventory in 914, while others can still upgrade items. This also checks the game's config settings to work with whatever 914 mode the server owners have set.